### PR TITLE
[FIX] Specify robot description topic when launching ros2 control

### DIFF
--- a/rm_motors_example/launch/rm_motors.launch.py
+++ b/rm_motors_example/launch/rm_motors.launch.py
@@ -34,6 +34,9 @@ def generate_launch_description():
         package="controller_manager",
         executable="ros2_control_node",
         parameters=[robot_controllers],
+        remappings=[
+            ("controller_manager/robot_description", "robot_description"),
+        ],
         output="both",
     )
 


### PR DESCRIPTION
This pull request introduces a small but important change to the `rm_motors.launch.py` file. It adds a remapping for the `controller_manager/robot_description` topic to `robot_description` in the `generate_launch_description()` function.

* [`rm_motors_example/launch/rm_motors.launch.py`](diffhunk://#diff-1aee945947f1aab662eb2cb5038b29d94f3cbb13337b856ad03646ec110baaaaR37-R39): Added a remapping for the `controller_manager/robot_description` topic to ensure proper topic communication within the launch file.

Without this fix, the hardware interface is locked by ros2 control and does not allow to find and initialize RoboMaster actuators, and therefore is not possible to run the example package.